### PR TITLE
chore(build): upgrade Go to 1.26

### DIFF
--- a/.github/workflows/pr-style.yml
+++ b/.github/workflows/pr-style.yml
@@ -30,7 +30,7 @@ jobs:
         ref: ${{ inputs.ref }}
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - name: Code Gen Check
       shell: bash
       run: make codegen-check

--- a/.github/workflows/pr-ut.yml
+++ b/.github/workflows/pr-ut.yml
@@ -28,7 +28,7 @@ jobs:
         ref: ${{ inputs.ref }}
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - name: Unit test
       shell: bash
       run: make ut

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work
 go.work.sum
 
 bin/**
+
+# Git worktrees
+.worktrees/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,15 +6,15 @@ version: "2"
 run:
   timeout: 5m
   modules-download-mode: readonly
-  go: "1.24"
+  go: "1.26"
 
 staticcheck:
-  go: "1.24"
+  go: "1.26"
   # https://staticcheck.io/docs/options#checks
   checks: [ "all" ]
 
 stylecheck:
-  go: "1.24"
+  go: "1.26"
 
 linters-settings:
   goimports:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # https://github.com/golangci/golangci-lint/releases/latest
-GOLANGCI_LINT_VERSION="2.5.0"
+GOLANGCI_LINT_VERSION="2.9.0"
 # https://github.com/uber-go/mock/releases
 MOCK_GEN_VERSION=0.6.0
 CURR_DIR=$(shell pwd)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/risingwavelabs/byoc-runtime
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/hashicorp/go-version v1.8.0


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.25 to 1.26 across `go.mod`, CI workflows, and `.golangci.yaml`
- Bump golangci-lint from 2.5.0 to 2.9.0 (adds Go 1.26 support)
- Fix `.golangci.yaml` Go version which was still at 1.24 (missed in #26)

Tracking: CLOUD-4567

## Test plan
- [x] CI style checks pass with Go 1.26
- [ ] CI unit tests pass with Go 1.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)