### PR TITLE
fix(terraform): skip checksum verification for expired HashiCorp GPG key

### DIFF
--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -429,6 +429,9 @@ func defaultInstallTerraform(ctx context.Context, dir, tfVersion, privateTFBinar
 		Version:    ver,
 		InstallDir: dir,
 		ApiBaseURL: privateTFBinaryBaseURL,
+		// TODO(CLOUD-4790): Remove once hashicorp/hc-install ships a release with the fix
+		// for the expired GPG key (https://github.com/hashicorp/hc-install/issues/370).
+		SkipChecksumVerification: true,
 	}
 
 	execPath, err := installer.Install(ctx)


### PR DESCRIPTION
## Summary

- Skip GPG checksum verification when installing Terraform via `hc-install` to work around the expired HashiCorp GPG key ([hashicorp/hc-install#370](https://github.com/hashicorp/hc-install/issues/370))
- The key (`C874011F0AB405110D02105534365D9472D7468F`) expired on 2026-04-18, breaking all BYOC provisioning (`rwc byoc apply`)
- This is a temporary workaround — should be reverted once upstream ships a fix ([hashicorp/hc-install#371](https://github.com/hashicorp/hc-install/pull/371))

Linear: CLOUD-4790

## Test plan

- [x] Existing unit tests pass
- [x] Linter passes
- [ ] Verify `rwc byoc apply` succeeds in test environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)